### PR TITLE
Remove camel dependencies from runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,5 @@
 dependencies {
     //Required compile-time and runtime dependencies
     pluginLibsCompile 'org.apache.camel:camel-core:2.21.0'
-    pluginLibsRuntime 'org.apache.camel:camel-core:2.21.0'
 }
 


### PR DESCRIPTION
As runtime extends compile-time dependencies. There should be no need to again add camel dependency as a runtime dependency.
See 
https://docs.gradle.org/2.12/userguide/java_plugin.html
https://docs.gradle.org/4.9/userguide/java_plugin.html#java_plugin